### PR TITLE
Adding basic support for invalidationContexts (introduced in iOS 8)

### DIFF
--- a/PSTCollectionView/PSTCollectionViewCommon.h
+++ b/PSTCollectionView/PSTCollectionViewCommon.h
@@ -62,6 +62,8 @@
 
 - (void)collectionView:(PSTCollectionView *)collectionView didEndDisplayingSupplementaryView:(PSTCollectionReusableView *)view forElementOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath;
 
+- (void)collectionView:(PSTCollectionView *)collectionView willDisplayCell:(PSTCollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath;
+
 // These methods provide support for copy/paste actions on cells.
 // All three should be implemented if any are.
 - (BOOL)collectionView:(PSTCollectionView *)collectionView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath;

--- a/PSTCollectionView/PSTCollectionViewData.h
+++ b/PSTCollectionView/PSTCollectionViewData.h
@@ -7,7 +7,7 @@
 
 #import "PSTCollectionViewCommon.h"
 
-@class PSTCollectionView, PSTCollectionViewLayout, PSTCollectionViewLayoutAttributes;
+@class PSTCollectionView, PSTCollectionViewLayout, PSTCollectionViewLayoutAttributes, PSTCollectionViewLayoutInvalidationContext;
 
 // https://github.com/steipete/iOS6-Runtime-Headers/blob/master/UICollectionViewData.h
 @interface PSTCollectionViewData : NSObject
@@ -45,6 +45,7 @@
 
 // Make data to re-evaluate dataSources.
 - (void)invalidate;
+- (void)invalidateWithContext:(PSTCollectionViewLayoutInvalidationContext *)invalidationContext;
 
 // Access cached item data
 - (NSInteger)numberOfItemsBeforeSection:(NSInteger)section;

--- a/PSTCollectionView/PSTCollectionViewData.m
+++ b/PSTCollectionView/PSTCollectionViewData.m
@@ -7,6 +7,7 @@
 
 #import "PSTCollectionViewData.h"
 #import "PSTCollectionView.h"
+#import "PSTCollectionViewLayout.h"
 
 @interface PSTCollectionViewData () {
     CGRect _validLayoutRect;
@@ -74,6 +75,16 @@
 
 - (void)invalidate {
     _collectionViewDataFlags.itemCountsAreValid = NO;
+    _collectionViewDataFlags.layoutIsPrepared = NO;
+    _validLayoutRect = CGRectNull;  // don't set CGRectZero in case of _contentSize=CGSizeZero
+}
+
+- (void)invalidateWithContext:(PSTCollectionViewLayoutInvalidationContext *)invalidationContext{
+    
+    if (_collectionViewDataFlags.itemCountsAreValid == YES) {
+        _collectionViewDataFlags.itemCountsAreValid = !invalidationContext.invalidateDataSourceCounts && !invalidationContext.invalidateEverything;
+    }
+    
     _collectionViewDataFlags.layoutIsPrepared = NO;
     _validLayoutRect = CGRectNull;  // don't set CGRectZero in case of _contentSize=CGSizeZero
 }

--- a/PSTCollectionView/PSTCollectionViewLayout+Internals.h
+++ b/PSTCollectionView/PSTCollectionViewLayout+Internals.h
@@ -16,3 +16,10 @@
 @property (nonatomic, copy, readonly) NSDictionary *decorationViewExternalObjectsTables;
 
 @end
+
+
+@interface PSTCollectionViewLayoutInvalidationContext (Internals)
+@property (nonatomic, assign, readwrite) BOOL invalidateEverything; // set to YES when invalidation occurs because the collection view is sent -reloadData
+@property (nonatomic, assign, readwrite) BOOL invalidateDataSourceCounts; // if YES, the layout should requery
+@end
+

--- a/PSTImprovedCollectionView.podspec
+++ b/PSTImprovedCollectionView.podspec
@@ -11,7 +11,10 @@ Pod::Spec.new do |s|
   s.source = {
     :git => 'https://github.com/ba01ei/PSTImprovedCollectionView.git',
     :tag => "2.0.3" }
-  s.platform = :ios, '4.3'
+
+  s.ios.deployment_target = '4.3'
+  s.tvos.deployment_target = '9.0'
+
   s.source_files = 'PSTCollectionView/'
   s.frameworks = 'UIKit', 'QuartzCore'
   s.requires_arc = true


### PR DESCRIPTION
iOS8's invalidationContexts allow layouts to support a smarter prepareLayout by noting what has actually changed.   I believe the changes are backward compatible still.
